### PR TITLE
Fix three code bugs

### DIFF
--- a/src/es-client-parser.js
+++ b/src/es-client-parser.js
@@ -298,13 +298,8 @@ export class ESClientParser {
     // Extract fields from bulk operation bodies
     this.extractFieldsFromDocumentBody(bulkContent, fields);
     
-    // Also look for index/update operations
-    const actionPattern = /"(index|create|update)"\s*:\s*\{[^}]*"_index"\s*:\s*['"']([^'"']+)['"']/g;
-    let match;
-    while ((match = actionPattern.exec(bulkContent)) !== null) {
-      // Extract any field-like patterns from the bulk operations
-      this.extractFromQueryDSL(bulkContent, fields);
-    }
+    // Scan the bulk block once for Query DSL-like field references
+    this.extractFromQueryDSL(bulkContent, fields);
   }
 
   extractFieldsFromTypescriptInterfaces(content, fields) {

--- a/src/field-parser.js
+++ b/src/field-parser.js
@@ -555,7 +555,6 @@ export class FieldParser {
       // Console and logging
       /^console\./i,
       /^logger\./i,
-      /^log\./i,
       
       // Node.js/JavaScript built-ins
       /^process\./i,

--- a/src/file-scanner.js
+++ b/src/file-scanner.js
@@ -195,9 +195,13 @@ export class FileScanner {
     const fileName = path.basename(filePath);
     const fileExt = path.extname(filePath).toLowerCase();
     
-    // Skip certain file types
-    const skipExtensions = ['.map', '.min.js', '.bundle.js', '.d.ts'];
+    // Skip certain file types and known minified/bundled artifacts
+    const skipExtensions = ['.map', '.d.ts'];
     if (skipExtensions.includes(fileExt)) {
+      return true;
+    }
+    const lowerFileName = fileName.toLowerCase();
+    if (lowerFileName.endsWith('.min.js') || lowerFileName.endsWith('.bundle.js')) {
       return true;
     }
 


### PR DESCRIPTION
Fix three bugs: incorrect skipping of minified/bundled JS files, redundant DSL scanning in bulk body parsing, and erroneous exclusion of valid ECS `log.*` fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f505234-6306-4e01-8ffb-643cc9ed50d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f505234-6306-4e01-8ffb-643cc9ed50d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

