### PR TITLE
Fix: Replace this.isValidESFieldName() with utilIsValidESFieldName() for consistency

### DIFF
--- a/src/field-parser.js
+++ b/src/field-parser.js
@@ -308,7 +308,7 @@ export class FieldParser {
         if (utilIsValidESFieldName(currentFieldPath)) {
           fields.add(currentFieldPath);
         }
-      } else if (this.isValidESFieldName(currentFieldPath)) {
+      } else if (utilIsValidESFieldName(currentFieldPath)) {
         // Add the field path even if it doesn't have an explicit type
         fields.add(currentFieldPath);
       }
@@ -348,9 +348,6 @@ export class FieldParser {
     return utilIsValidExtractedFieldName(fieldName);
   }
 
-  isValidESFieldName(fieldName) {
-    return utilIsValidESFieldName(fieldName);
-  }
 
 
   isValidECSFieldName(fieldName) {


### PR DESCRIPTION
## Summary

Fixed inconsistent method call in `field-parser.js` where `this.isValidESFieldName()` was called instead of the imported utility function.

## Changes

- Replaced `this.isValidESFieldName()` with `utilIsValidESFieldName()` on line 311
- Removed redundant `isValidESFieldName` method that just called utility function
- All validation calls now use imported utility functions consistently

Fixes #9

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces a call to this.isValidESFieldName with utilIsValidESFieldName and deletes the redundant isValidESFieldName method in field-parser.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 780b0e1525659da0939165738e94d9f0893870bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->